### PR TITLE
:bug: fix package bug

### DIFF
--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -121,7 +121,7 @@ let rendererConfig = {
   plugins: [
     new ExtractTextPlugin('styles.css'),
     new webpack.DefinePlugin({
-      'process.env': config.dev.env
+      'process.env': process.env.NODE_ENV === 'production' ? config.build.env : config.dev.env
     }),
     new HtmlWebpackPlugin({
       filename: 'index.html',


### PR DESCRIPTION
`DefinePlugin` plugin of this configuration in `webpack.renderer.config.js` was writen into `dev` environment，that's why you can't switch it into `prod environment` while you are packing