### PR TITLE
update electron-builder version for fix "Building on macOS 10.15 fails"

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "electron": "^1.7.5",
     "electron-debug": "^1.4.0",
     "electron-devtools-installer": "^2.2.0",
-    "electron-builder": "^19.19.1",
+    "electron-builder": "^22.7.0",
     "babel-eslint": "^7.2.3",
     "eslint": "^4.4.1",
     "eslint-friendly-formatter": "^3.0.0",


### PR DESCRIPTION
update electron-builder version for fix "Building on macOS 10.15 fails. Can't locate Mac/Memory.pm"

ref: https://github.com/electron-userland/electron-builder/issues/3990